### PR TITLE
Directly use `IntermediateOutputPath`.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
         id: pack-options-nightly
         run: echo "value=--version-suffix ${{ github.event_name == 'push' && 'nightly' || github.ref_name }}.${{ github.run_number }}" >> $GITHUB_OUTPUT
       - name: Pack
-        run: dotnet pack -c Release -o ./pack ${{ steps.pack-options-nightly.outputs.value }}
+        run: dotnet pack ./Sigourney.Shipping.slnf -c Release -o ./pack ${{ steps.pack-options-nightly.outputs.value }}
       - name: Upload package artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/Sigourney.Shipping.slnf
+++ b/Sigourney.Shipping.slnf
@@ -1,0 +1,9 @@
+{
+  "solution": {
+    "path": "Sigourney.sln",
+    "projects": [
+      "src\\Sigourney.Build\\Sigourney.Build.csproj",
+      "src\\Sigourney\\Sigourney.csproj"
+    ]
+  }
+}

--- a/Sigourney.sln.DotSettings
+++ b/Sigourney.sln.DotSettings
@@ -1,6 +1,0 @@
-﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
-	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/LINE_FEED_AT_FILE_END/@EntryValue">True</s:Boolean>
-	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpKeepExistingMigration/@EntryIndexedValue">True</s:Boolean>
-	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpPlaceEmbeddedOnSameLineMigration/@EntryIndexedValue">True</s:Boolean>
-	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpUseContinuousIndentInsideBracesMigration/@EntryIndexedValue">True</s:Boolean>
-	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateBlankLinesAroundFieldToBlankLinesAroundProperty/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/src/Sigourney.Build/build/Sigourney.Build.targets
+++ b/src/Sigourney.Build/build/Sigourney.Build.targets
@@ -8,8 +8,7 @@ https://opensource.org/licenses/MIT
   TreatAsLocalProperty="_SigourneyEnable">
   <Import Project="$(MSBuildThisFileDirectory)Sigourney.PublishMode.targets" />
   <PropertyGroup>
-    <IntermediateDirectory>$(ProjectDir)$(IntermediateOutputPath)</IntermediateDirectory>
-    <ProcessedBySigourney>$(IntermediateDirectory)ProcessedBySigourney</ProcessedBySigourney>
+    <ProcessedBySigourney>$(IntermediateOutputPath)ProcessedBySigourney</ProcessedBySigourney>
     <_SigourneyEnable Condition="$(SigourneyEnable) == false OR $(DesigntimeBuild) == true">false</_SigourneyEnable>
   </PropertyGroup>
 
@@ -21,7 +20,7 @@ https://opensource.org/licenses/MIT
     <ItemGroup>
       <SigourneyConfiguration Include="Sigourney default configuration">
         <SignAssembly>$(SignAssembly)</SignAssembly>
-        <IntermediateDirectory>$(IntermediateDirectory)</IntermediateDirectory>
+        <IntermediateDirectory>$(IntermediateOutputPath)</IntermediateDirectory>
         <KeyOriginatorFile>$(KeyOriginatorFile)</KeyOriginatorFile>
         <AssemblyOriginatorKeyFile>$(AssemblyOriginatorKeyFile)</AssemblyOriginatorKeyFile>
         <References>@(ReferencePath)</References>

--- a/src/Sigourney/Sigourney.csproj
+++ b/src/Sigourney/Sigourney.csproj
@@ -5,11 +5,7 @@
     <PackageId>Sigourney</PackageId>
     <Description>A lightweight toolkit that helps easily writing .NET assembly weavers.</Description>
     <Copyright>$(Copyright) Contains some code from Fody, which is licensed under the MIT License as well.</Copyright>
-    <PackageReleaseNotes>Sigourney's build-time assets were moved to a new package, https://nuget.org/packages/Sigourney.Build, resulting in smaller download sizes and less dependencies. Weavers will need to be updated to publicly reference Sigourney.Build instead, as seen in the test weavers.
-
-Legacy code that was supporting weavers targeting versions of Sigourney prior to 0.3.0 was removed.
-
-Version 4.0.1 fixed a bug where Sigourney did not run on F#.</PackageReleaseNotes>
+    <PackageReleaseNotes>Fixed weaving under certain build environments like BenchmarkDotNet.</PackageReleaseNotes>
     <PackageTags>$(PackageTags);Cecil</PackageTags>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <LangVersion>8.0</LangVersion>

--- a/src/Sigourney/Sigourney.csproj
+++ b/src/Sigourney/Sigourney.csproj
@@ -12,9 +12,6 @@ Legacy code that was supporting weavers targeting versions of Sigourney prior to
 Version 4.0.1 fixed a bug where Sigourney did not run on F#.</PackageReleaseNotes>
     <PackageTags>$(PackageTags);Cecil</PackageTags>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <EmbedUntrackedSources>true</EmbedUntrackedSources>
-    <IncludeSymbols>true</IncludeSymbols>
-    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <LangVersion>8.0</LangVersion>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/Sigourney/WeaverConfig.cs
+++ b/src/Sigourney/WeaverConfig.cs
@@ -35,8 +35,8 @@ namespace Sigourney
         /// <summary>
         /// The "obj/" directory used in the build.
         /// </summary>
-        /// <remarks>It is derieved from the MSBuild
-        /// "IntermediateDirectory" property.</remarks>
+        /// <remarks>It is derieved from the MSBuild "IntermediateOutputPath" property.</remarks>
+        // TODO: Deprecate in the next minor release and replace with IntermediateOutputPath.
         public string? IntermediateDirectory { get; set; }
 
         /// <summary>

--- a/src/nuget.props
+++ b/src/nuget.props
@@ -1,6 +1,6 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <VersionPrefix>0.4.1</VersionPrefix>
+    <VersionPrefix>0.4.2</VersionPrefix>
     <Authors>Theodore Tsirpanis</Authors>
     <Copyright>Copyright © Theodore Tsirpanis. Licensed under the MIT License.</Copyright>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/nuget.props
+++ b/src/nuget.props
@@ -1,6 +1,6 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <Version>0.4.1</Version>
+    <VersionPrefix>0.4.1</VersionPrefix>
     <Authors>Theodore Tsirpanis</Authors>
     <Copyright>Copyright © Theodore Tsirpanis. Licensed under the MIT License.</Copyright>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>


### PR DESCRIPTION
Some environments like BenchmarkDotNet set it to an absolute path. Instead of appending it to the project directory, we just use it and hope MSBuild takes care of the rest.

Likely fixes a bug [reported](https://discord.com/channels/944706562948231188/944989186488942603/1313648120873226264) in the Farkle Discord server.